### PR TITLE
Use RBASIC_SET_CLASS macro to build under Ruby 2.1.0.

### DIFF
--- a/ext/linalg.c
+++ b/ext/linalg.c
@@ -71,7 +71,12 @@ static VALUE rb_gsl_linalg_LU_decomposition(int argc, VALUE *argv, VALUE obj, in
   Data_Get_Struct(omatrix, gsl_matrix, mtmp);
   if (flag == LINALG_DECOMP_BANG) {
     m = mtmp;
+#ifdef RBASIC_CLASS
+    RBASIC_SET_CLASS(omatrix, cgsl_matrix_LU);
+#endif
+#ifndef RBASIC_CLASS
     RBASIC(omatrix)->klass = cgsl_matrix_LU;
+#endif
     objm = omatrix;
   } else {
     m = make_matrix_clone(mtmp);
@@ -692,7 +697,12 @@ static VALUE rb_gsl_linalg_QR_LQ_decomposition(int argc, VALUE *argv, VALUE obj,
     fdecomp = &gsl_linalg_QR_decomp;
     m = mtmp;
     mdecomp = omatrix;
+#ifdef RBASIC_CLASS
+    RBASIC_SET_CLASS(mdecomp, cgsl_matrix_QR);
+#endif
+#ifndef RBASIC_CLASS
     RBASIC(mdecomp)->klass = cgsl_matrix_QR;
+#endif
     break;
 #ifdef GSL_1_6_LATER
   case LINALG_LQ_DECOMP:
@@ -704,7 +714,12 @@ static VALUE rb_gsl_linalg_QR_LQ_decomposition(int argc, VALUE *argv, VALUE obj,
     fdecomp = &gsl_linalg_LQ_decomp;
     m = mtmp;
     mdecomp = omatrix;
-    RBASIC(mdecomp)->klass = cgsl_matrix_LQ;
+#ifdef RBASIC_CLASS
+    RBASIC_SET_CLASS(mdecomp, cgsl_matrix_LQ);
+#endif
+#ifndef RBASIC_CLASS
+    RBASIC(mdecomp)->klass = cgsl_matrix_LQ);
+#endif
     break;
 #endif
   default:
@@ -731,7 +746,12 @@ static VALUE rb_gsl_linalg_QR_LQ_decomposition(int argc, VALUE *argv, VALUE obj,
       vtau = Data_Wrap_Struct(cgsl_vector_tau, 0, gsl_vector_free, tau);
       return rb_ary_new3(2, mdecomp, vtau);
     } else {
+#ifdef RBASIC_CLASS
+      RBASIC_SET_CLASS(argv[itmp], cgsl_vector_tau);
+#endif
+#ifndef RBASIC_CLASS
       RBASIC(argv[itmp])->klass = cgsl_vector_tau;
+#endif
       return mdecomp;
     }
     break;
@@ -740,7 +760,12 @@ static VALUE rb_gsl_linalg_QR_LQ_decomposition(int argc, VALUE *argv, VALUE obj,
    if (argc == itmp) {
       return Data_Wrap_Struct(cgsl_vector_tau, 0, gsl_vector_free, tau);
     } else {
-      RBASIC(argv[itmp])->klass = cgsl_vector_tau;
+#ifdef RBASIC_CLASS
+     RBASIC_SET_CLASS(argv[itmp], cgsl_vector_tau);
+#endif
+#ifndef RBASIC_CLASS
+     RBASIC(argv[itmp])->klass = cgsl_vector_tau;
+#endif
       return INT2FIX(status);
     }
     break;
@@ -1628,14 +1653,24 @@ static VALUE rb_gsl_linalg_QRLQPT_decomp_bang(int argc, VALUE *argv, VALUE obj, 
   norm = gsl_vector_alloc(size0);
   switch (flag) {
   case LINALG_QRPT:
+#ifdef RBASIC_CLASS
+    RBASIC_SET_CLASS(vA, cgsl_matrix_QRPT);
+#endif
+#ifndef RBASIC_CLASS
     RBASIC(vA)->klass = cgsl_matrix_QRPT;
+#endif
     vtau = Data_Wrap_Struct(cgsl_vector_tau, 0, gsl_vector_free, tau);
     vp = Data_Wrap_Struct(cgsl_permutation, 0, gsl_permutation_free, p);
     gsl_linalg_QRPT_decomp(A, tau, p, &signum, norm);
     break;
 #ifdef GSL_1_6_LATER
   case LINALG_PTLQ:
-    RBASIC(vA)->klass = cgsl_matrix_PTLQ;
+#ifdef RBASIC_CLASS
+    RBASIC_SET_CLASS(vA, cgsl_matrix_PTLQ);
+#endif
+#ifndef RBASIC_CLASS
+    RBASIC(vA)->klass = cgsl_matrix_PTLQ);
+#endif
     vtau = Data_Wrap_Struct(cgsl_vector_tau, 0, gsl_vector_free, tau);
     vp = Data_Wrap_Struct(cgsl_permutation, 0, gsl_permutation_free, p);
     gsl_linalg_PTLQ_decomp(A, tau, p, &signum, norm);

--- a/ext/linalg_complex.c
+++ b/ext/linalg_complex.c
@@ -51,8 +51,21 @@ VALUE rb_gsl_linalg_complex_LU_decomp(int argc, VALUE *argv, VALUE obj)
   case 0:
     p = gsl_permutation_alloc(size);
     gsl_linalg_complex_LU_decomp(m, p, &signum);
-    if (itmp == 1) RBASIC(argv[0])->klass = cgsl_matrix_complex_LU;
-    else RBASIC(obj)->klass = cgsl_matrix_complex_LU;
+    if (itmp == 1) {
+#ifdef RBASIC_CLASS
+      RBASIC_SET_CLASS(argv[0], cgsl_matrix_complex_LU);
+#endif
+#ifndef RBASIC_CLASS
+      RBASIC(argv[0])->klass = cgsl_matrix_complex_LU;
+#endif
+    } else {
+#ifdef RBASIC_CLASS
+      RBASIC_SET_CLASS(obj, cgsl_matrix_complex_LU);
+#endif
+#ifndef RBASIC_CLASS
+      RBASIC(obj)->klass = cgsl_matrix_complex_LU;
+#endif
+    }
     obj2 = Data_Wrap_Struct(cgsl_permutation, 0, gsl_permutation_free, p);
     return rb_ary_new3(2, obj2, INT2FIX(signum));
     break;
@@ -60,8 +73,21 @@ VALUE rb_gsl_linalg_complex_LU_decomp(int argc, VALUE *argv, VALUE obj)
     CHECK_PERMUTATION(argv[itmp]);
     Data_Get_Struct(argv[itmp], gsl_permutation, p);
     gsl_linalg_complex_LU_decomp(m, p, &signum);
-    if (itmp == 1) RBASIC(argv[0])->klass = cgsl_matrix_complex_LU;
-    else RBASIC(obj)->klass = cgsl_matrix_complex_LU;
+    if (itmp == 1) {
+#ifdef RBASIC_CLASS
+      RBASIC_SET_CLASS(argv[0], cgsl_matrix_complex_LU);
+#endif
+#ifndef RBASIC_CLASS
+      RBASIC(argv[0])->klass = cgsl_matrix_complex_LU;
+#endif
+    } else {
+#ifdef RBASIC_CLASS
+      RBASIC_SET_CLASS(obj, cgsl_matrix_complex_LU);
+#endif
+#ifndef RBASIC_CLASS
+      RBASIC(obj)->klass = cgsl_matrix_complex_LU;
+#endif
+    }
     return INT2FIX(signum);
     break;
   default:

--- a/ext/vector_complex.c
+++ b/ext/vector_complex.c
@@ -938,11 +938,22 @@ static VALUE rb_gsl_vector_complex_trans(VALUE obj)
 
 static VALUE rb_gsl_vector_complex_trans2(VALUE obj)
 {
-  if (CLASS_OF(obj) == cgsl_vector_complex) 
+  if (CLASS_OF(obj) == cgsl_vector_complex) {
+#ifdef RBASIC_CLASS
+    RBASIC_SET_CLASS(obj, cgsl_vector_complex_col);
+#endif
+#ifndef RBASIC_CLASS
     RBASIC(obj)->klass = cgsl_vector_complex_col;
-  else if (CLASS_OF(obj) == cgsl_vector_complex_col) 
+#endif
+  } else if (CLASS_OF(obj) == cgsl_vector_complex_col) {
+#ifdef RBASIC_CLASS
+    RBASIC_SET_CLASS(obj, cgsl_vector_complex);
+#endif
+#ifndef RBASIC_CLASS
     RBASIC(obj)->klass = cgsl_vector_complex;
-  else {
+#endif
+
+  } else {
     rb_raise(rb_eRuntimeError, "method trans! for %s is forbidden",
 	     rb_class2name(CLASS_OF(obj)));
   }

--- a/ext/vector_source.c
+++ b/ext/vector_source.c
@@ -673,16 +673,40 @@ static VALUE FUNCTION(rb_gsl_vector,trans)(VALUE obj)
 static VALUE FUNCTION(rb_gsl_vector,trans_bang)(VALUE obj)
 {
 #ifdef BASE_DOUBLE
-  if (CLASS_OF(obj) == cgsl_vector) RBASIC(obj)->klass = cgsl_vector_col;
-  else if (CLASS_OF(obj) == cgsl_vector_col) RBASIC(obj)->klass = cgsl_vector;
-  else {
+  if (CLASS_OF(obj) == cgsl_vector) {
+#ifdef RBASIC_CLASS
+    RBASIC_SET_CLASS(obj, cgsl_vector_col);
+#endif
+#ifndef RBASIC_CLASS
+    RBASIC(obj)->klass = cgsl_vector_col;
+#endif
+  } else if (CLASS_OF(obj) == cgsl_vector_col) {
+#ifdef RBASIC_CLASS
+    RBASIC_SET_CLASS(obj, cgsl_vector);
+#endif
+#ifndef RBASIC_CLASS
+    RBASIC(obj)->klass = cgsl_vector;
+#endif
+  } else {
     rb_raise(rb_eRuntimeError, "method trans! for %s is not permitted.",
 	     rb_class2name(CLASS_OF(obj)));
   }	
 #elif defined(BASE_INT)
-  if (CLASS_OF(obj) == cgsl_vector_int) RBASIC(obj)->klass = cgsl_vector_int_col;
-  else if (CLASS_OF(obj) == cgsl_vector_int_col) RBASIC(obj)->klass = cgsl_vector_int;
-  else {
+  if (CLASS_OF(obj) == cgsl_vector_int) {
+#ifdef RBASIC_CLASS
+    RBASIC_SET_CLASS(obj, cgsl_vector_int_col);
+#endif
+#ifndef RBASIC_CLASS
+      RBASIC(obj)->klass = cgsl_vector_int_col;
+#endif
+  } else if (CLASS_OF(obj) == cgsl_vector_int_col) {
+#ifdef RBASIC_CLASS
+    RBASIC_SET_CLASS(obj, cgsl_vector_int);
+#endif
+#ifndef RBASIC_CLASS
+    RBASIC(obj)->klass = cgsl_vector_int;
+#endif
+  } else {
     rb_raise(rb_eRuntimeError, "method trans! for %s is not permitted.",
 	     rb_class2name(CLASS_OF(obj)));
   }


### PR DESCRIPTION
This change uses RBASIC_SET_CLASS(obj, val) in Ruby 2.1.0, not RBASIC(obj)->klass = val, which is used in other versions. 

This uses Ruby internal macros brought in with GC changes in 2.1.0, if there is a better way to achieve this, I'm all ears.
